### PR TITLE
Fixes the pricing plan selector

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ function addEventListeners() {
 
     const selectPricingPlan = document.getElementById("select-pricing-plan");
     selectPricingPlan.addEventListener("change", async => {
-        selectedPricingIndex = selectPricingPlan.value;
+        currentPricingOptions.selectedPricingIndex = selectPricingPlan.value;
         refreshPricing(currentPricingOptions);
     });
 

--- a/javascript/pricing.js
+++ b/javascript/pricing.js
@@ -67,5 +67,5 @@ async function refreshPricing({
     } if (pricingPlan.per_km_pricing !== undefined) {
         price += await getGbfsPricePerKm(pricingPlan, currentDistance)
     }
-    document.getElementById("price").textContent = price + pricingPlan.currency;
+    document.getElementById("price").textContent = price + " " + pricingPlan.currency;
 }


### PR DESCRIPTION
@nbdh noticed that when looking at a GBFS feed with multiple pricing plans, the selector will always "jump back" to the first plan. This should fix it so the selection sticks. Also, it adds a space between price and currency.

Try it out on https://zimmerling.github.io/gbfs-viewer/ by selecting "WienMobil Rad" 👍

(https://github.com/zimmerling/gbfs-viewer/pull/1)